### PR TITLE
Values of 0 are treated as NULL

### DIFF
--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -8,7 +8,7 @@
         name="{{ field_type.input_name }}"
         data-decimals="{{ field_type.config.decimals }}"
         placeholder="{{ trans(field_type.placeholder) }}"
-        value="{{ field_type.value != null ? field_type.value|number_format(field_type.config.decimals, null, false) }}"
+        value="{{ field_type.value is not null ? field_type.value|number_format(field_type.config.decimals, null, false) }}"
         {{ html_attributes(field_type.attributes) }}
         {{ field_type.disabled ? 'disabled' }}
         {{ field_type.readonly ? 'readonly' }}>


### PR DESCRIPTION
If the field has a value of "0" the lose comparison determines it is equal to NULL and should be left blank.

When a value of "0" is loaded from the DB the the fields value attribute isn't set. When re-submitting the form 0 must be manually entered into the field for it to pass validation (numeric). This can become annoying when there are multiple fields on a page.