### PR TITLE
0 min/max config value should not be treated as null.

### DIFF
--- a/src/DecimalFieldType.php
+++ b/src/DecimalFieldType.php
@@ -76,11 +76,11 @@ class DecimalFieldType extends FieldType
     {
         $rules = parent::getRules();
 
-        if ($min = array_get($this->config, 'min')) {
+        if (null !== ($min = array_get($this->config, 'min'))) {
             $rules[] = 'min:' . $min;
         }
 
-        if ($max = array_get($this->config, 'max')) {
+        if (null !== ($max = array_get($this->config, 'max'))) {
             $rules[] = 'max:' . $max;
         }
 

--- a/src/DecimalFieldType.php
+++ b/src/DecimalFieldType.php
@@ -76,11 +76,11 @@ class DecimalFieldType extends FieldType
     {
         $rules = parent::getRules();
 
-        if (null !== ($min = array_get($this->config, 'min'))) {
+        if (!is_null($min = array_get($this->config, 'min'))) {
             $rules[] = 'min:' . $min;
         }
 
-        if (null !== ($max = array_get($this->config, 'max'))) {
+        if (!is_null($max = array_get($this->config, 'max'))) {
             $rules[] = 'max:' . $max;
         }
 


### PR DESCRIPTION
There was a previous fix for this merged in 2017, but it was only in the view. If the min/max config value for the decimal field type is set to 0, it is treated as null during validation.